### PR TITLE
Fix casting in Oscvalue2Fadervalue function

### DIFF
--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -168,7 +168,7 @@ float Helper::Fadervalue2DMX(uint16_t fadervalue)
 }
 
 uint16_t Helper::Oscvalue2Fadervalue(float oscValue){
-	return (uint16_t)oscValue * 0x0FFF;
+	return (uint16_t)(oscValue * 0x0FFF);
 }
 
 float Helper::Fadervalue2Oscvalue(uint16_t faderValue){


### PR DESCRIPTION
oscValue of <1f would have been truncated before multiplication giving return of 0 instead of 2047.5, which would truncate to 2047.